### PR TITLE
Removed npm run build.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 
@@ -23,5 +23,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
There is no need to run the build script because we don't test the compiled CommonJS code. The test scripts weren't working because of a problem with rollup.